### PR TITLE
[API] adding stream_types object and tag to forgetAll api

### DIFF
--- a/src/features/Apiexplorer/Schema/RecursiveContent/RecursiveProperties/__tests__/RecursiveProperties.test.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/RecursiveProperties/__tests__/RecursiveProperties.test.tsx
@@ -13,8 +13,34 @@ const fakeItem = {
     },
   },
   properties: {
-    recursive_item: {
+    recursive_item_1: {
       description: 'This is a recursive item',
+    },
+    recursive_item_2: {
+      description: 'This is recursive item 2',
+      oneOf: 'This is oneOf key for recursive_item_2',
+    },
+  },
+  definitions: {
+    stream_types: {
+      description: 'This stream_types description',
+      type: 'string',
+      enum: [
+        'balance',
+        'candles',
+        'cashier_payments',
+        'p2p_advert',
+        'p2p_advertiser',
+        'p2p_order',
+        'proposal',
+        'proposal_open_contract',
+        'ticks',
+        'transaction',
+        'trading_platform_asset_listing',
+        'website_status',
+        'p2p_settings',
+        'crypto_estimations',
+      ],
     },
   },
 };
@@ -26,21 +52,43 @@ describe('RecursiveProperties', () => {
         is_open
         properties={fakeItem.properties || fakeItem?.items?.properties}
         value={fakeItem}
+        jsonSchema={fakeItem}
       />,
     );
     const recursion_1_description = await screen.findByText(/nested items/i);
     expect(recursion_1_description).toBeVisible();
 
-    const recursion_2_name = await screen.findByText(/recursive_item/i);
+    const recursion_2_name = await screen.findByText(/recursive_item_1/i);
     expect(recursion_2_name).toBeVisible();
 
     const recursion_2_description = await screen.findByText(/This is a recursive item/i);
     expect(recursion_2_description).toBeVisible();
+
+    const recursion_3_name = await screen.findByText(/recursive_item_2/i);
+    expect(recursion_3_name).toBeVisible();
+
+    const recursion_3_description = await screen.findByText(/This is recursive item 2/i);
+    expect(recursion_3_description).toBeVisible();
   });
 
   it('renders only the description (last item) if there are no nested items anymore', async () => {
-    render(<RecursiveProperties is_open properties={null} value={fakeItem} />);
+    render(
+      <RecursiveProperties is_open properties={null} value={fakeItem} jsonSchema={fakeItem} />,
+    );
     const item = await screen.findByText(/This is the main item description/i);
     expect(item).toBeVisible();
+  });
+
+  it('renders StreamTypesObject if value contains oneOf meaning its forgetAll api call', async () => {
+    render(
+      <RecursiveProperties
+        is_open
+        properties={null}
+        value={fakeItem.properties.recursive_item_2}
+        jsonSchema={fakeItem}
+      />,
+    );
+    const streamTypesObject = await screen.getByTestId('dt_stream_types_object');
+    expect(streamTypesObject).toBeVisible();
   });
 });

--- a/src/features/Apiexplorer/Schema/RecursiveContent/RecursiveProperties/index.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/RecursiveProperties/index.tsx
@@ -44,7 +44,7 @@ const RecursiveProperties = ({ is_open, properties, value, jsonSchema }: TRecurs
                 key_value={key}
                 properties={properties}
                 jsonSchema={jsonSchema}
-                is_stream_types={true}
+                is_stream_types
               />
             ) : (
               <SchemaObjectContent key={key} key_value={key} properties={properties} />

--- a/src/features/Apiexplorer/Schema/RecursiveContent/RecursiveProperties/index.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/RecursiveProperties/index.tsx
@@ -7,20 +7,22 @@ type TRecursiveProperties = {
   is_open: boolean;
   properties: any;
   value: any;
-  jsonSchema?: any;
+  jsonSchema: any;
 };
 
 const RecursiveProperties = ({ is_open, properties, value, jsonSchema }: TRecursiveProperties) => {
   const keys = properties && Object.keys(properties);
+
   if (!is_open) {
-    //if object is not open then ret null
     return null;
   }
-
-  if ('oneOf' in value) {
-    return <StreamTypesObject definitions={jsonSchema.definitions} />;
+  if (value && 'oneOf' in value) {
+    return (
+      <React.Fragment>
+        <StreamTypesObject definitions={jsonSchema.definitions} />
+      </React.Fragment>
+    );
   }
-  // this will be true when we are not inside properties obj? !!!!!!
   if (!keys) {
     return (
       <React.Fragment>
@@ -36,7 +38,6 @@ const RecursiveProperties = ({ is_open, properties, value, jsonSchema }: TRecurs
             {index === 0 && value?.items?.description && (
               <SchemaDescription description={value.items.description} />
             )}
-            {/* check if its forgetAll Request not response */}
             {key === 'forget_all' && 'oneOf' in value[key] ? (
               <SchemaObjectContent
                 key={key}

--- a/src/features/Apiexplorer/Schema/RecursiveContent/RecursiveProperties/index.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/RecursiveProperties/index.tsx
@@ -1,18 +1,26 @@
 import React from 'react';
 import SchemaDescription from '../SchemaDescription';
 import SchemaObjectContent from '../SchemaObjectContent';
+import StreamTypesObject from '../StreamTypesObject';
 
 type TRecursiveProperties = {
   is_open: boolean;
   properties: any;
   value: any;
+  jsonSchema?: any;
 };
 
-const RecursiveProperties = ({ is_open, properties, value }: TRecursiveProperties) => {
+const RecursiveProperties = ({ is_open, properties, value, jsonSchema }: TRecursiveProperties) => {
   const keys = properties && Object.keys(properties);
   if (!is_open) {
+    //if object is not open then ret null
     return null;
   }
+
+  if ('oneOf' in value) {
+    return <StreamTypesObject definitions={jsonSchema.definitions} />;
+  }
+  // this will be true when we are not inside properties obj? !!!!!!
   if (!keys) {
     return (
       <React.Fragment>
@@ -28,7 +36,18 @@ const RecursiveProperties = ({ is_open, properties, value }: TRecursivePropertie
             {index === 0 && value?.items?.description && (
               <SchemaDescription description={value.items.description} />
             )}
-            <SchemaObjectContent key={key} key_value={key} properties={properties} />
+            {/* check if its forgetAll Request not response */}
+            {key === 'forget_all' && 'oneOf' in value[key] ? (
+              <SchemaObjectContent
+                key={key}
+                key_value={key}
+                properties={properties}
+                jsonSchema={jsonSchema}
+                is_stream_types={true}
+              />
+            ) : (
+              <SchemaObjectContent key={key} key_value={key} properties={properties} />
+            )}
           </React.Fragment>
         );
       })}

--- a/src/features/Apiexplorer/Schema/RecursiveContent/SchemaBodyHeader/__tests__/SchemaBodyHeader.test.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/SchemaBodyHeader/__tests__/SchemaBodyHeader.test.tsx
@@ -16,6 +16,7 @@ describe('SchemaBodyHeader', () => {
         title='test title'
         is_open_object
         setIsOpenObject={() => jest.fn()}
+        is_stream_types={false}
       />,
     );
     const type = await screen.findByText('number');
@@ -34,6 +35,7 @@ describe('SchemaBodyHeader', () => {
         title='test title'
         is_open_object
         setIsOpenObject={() => jest.fn()}
+        is_stream_types={false}
       />,
     );
     const type = await screen.findByText('array');
@@ -52,6 +54,7 @@ describe('SchemaBodyHeader', () => {
         title='test title'
         is_open_object
         setIsOpenObject={() => jest.fn()}
+        is_stream_types={false}
       />,
     );
     const type = await screen.findByText('integer');
@@ -70,6 +73,7 @@ describe('SchemaBodyHeader', () => {
         title='test title'
         is_open_object
         setIsOpenObject={() => jest.fn()}
+        is_stream_types={false}
       />,
     );
     const type = await screen.findByText('string');
@@ -88,6 +92,7 @@ describe('SchemaBodyHeader', () => {
         title='test title'
         is_open_object
         setIsOpenObject={() => jest.fn()}
+        is_stream_types={false}
       />,
     );
     const type = await screen.findByText(/number/i);
@@ -106,6 +111,7 @@ describe('SchemaBodyHeader', () => {
         title='test title'
         is_open_object
         setIsOpenObject={() => jest.fn()}
+        is_stream_types={false}
       />,
     );
     const type = await screen.findByText(/string/i);
@@ -124,6 +130,7 @@ describe('SchemaBodyHeader', () => {
         title='test title'
         is_open_object
         setIsOpenObject={() => jest.fn()}
+        is_stream_types={false}
       />,
     );
     const type = await screen.findByText(/array/i);
@@ -142,9 +149,33 @@ describe('SchemaBodyHeader', () => {
         title='test title'
         is_open_object
         setIsOpenObject={() => jest.fn()}
+        is_stream_types={false}
       />,
     );
     const type = await screen.findByText(/integer/i);
     expect(type).toBeVisible();
+  });
+
+  it('should render the SchemaBodyHeader with oneOf stream_types array if is_stream_types is true', async () => {
+    render(
+      <SchemaBodyHeader
+        key_value={null}
+        type={null}
+        defaultValue='default_test'
+        pattern=''
+        examples={null}
+        enum={null}
+        title=''
+        is_open_object
+        setIsOpenObject={() => jest.fn()}
+        is_stream_types={true}
+      />,
+    );
+    const oneOfType = await screen.findByText(/one of/i);
+    const stream_types = await screen.findByText(/stream_types/i);
+    const array_type = await screen.findByText(/array/i);
+    expect(oneOfType).toBeVisible();
+    expect(stream_types).toBeVisible();
+    expect(array_type).toBeVisible();
   });
 });

--- a/src/features/Apiexplorer/Schema/RecursiveContent/SchemaBodyHeader/index.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/SchemaBodyHeader/index.tsx
@@ -121,9 +121,9 @@ const SchemaBodyHeader = ({
 
             {is_stream_types && (
               <div className={styles.schemaObjectContent}>
-                <span className={styles.enumLabel}>{'one of'}</span>
-                <button onClick={() => setIsOpenObject(!is_open_object)}>{'stream_types'}</button>
-                <span className={`${styles.enumType} ${styles.array}`}>{'array'}</span>
+                <span className={styles.enumLabel}>one of</span>
+                <button onClick={() => setIsOpenObject(!is_open_object)}>stream_types</button>
+                <span className={`${styles.enumType} ${styles.array}`}>array</span>
               </div>
             )}
 

--- a/src/features/Apiexplorer/Schema/RecursiveContent/SchemaBodyHeader/index.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/SchemaBodyHeader/index.tsx
@@ -12,7 +12,7 @@ type TSchemaBodyHeader = {
   setIsOpenObject: (boolean) => void;
   examples: string[];
   enum;
-  is_stream_types?: boolean;
+  is_stream_types: boolean;
 };
 
 const SchemaBodyHeader = ({

--- a/src/features/Apiexplorer/Schema/RecursiveContent/SchemaBodyHeader/index.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/SchemaBodyHeader/index.tsx
@@ -120,13 +120,11 @@ const SchemaBodyHeader = ({
             )}
 
             {is_stream_types && (
-              <React.Fragment>
-                <div className={styles.schemaObjectContent}>
-                  <span className={styles.enumLabel}>{'one of'}</span>
-                  <button onClick={() => setIsOpenObject(!is_open_object)}>{'stream_types'}</button>
-                  <span className={`${styles.enumType} ${styles.array}`}>{'array'}</span>
-                </div>
-              </React.Fragment>
+              <div className={styles.schemaObjectContent}>
+                <span className={styles.enumLabel}>{'one of'}</span>
+                <button onClick={() => setIsOpenObject(!is_open_object)}>{'stream_types'}</button>
+                <span className={`${styles.enumType} ${styles.array}`}>{'array'}</span>
+              </div>
             )}
 
             {pattern && (

--- a/src/features/Apiexplorer/Schema/RecursiveContent/SchemaBodyHeader/index.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/SchemaBodyHeader/index.tsx
@@ -12,6 +12,7 @@ type TSchemaBodyHeader = {
   setIsOpenObject: (boolean) => void;
   examples: string[];
   enum;
+  is_stream_types?: boolean;
 };
 
 const SchemaBodyHeader = ({
@@ -24,6 +25,7 @@ const SchemaBodyHeader = ({
   title,
   is_open_object,
   setIsOpenObject,
+  is_stream_types,
 }: TSchemaBodyHeader) => {
   let typeClassName;
   switch (type) {
@@ -116,6 +118,17 @@ const SchemaBodyHeader = ({
             ) : (
               <></>
             )}
+
+            {is_stream_types && (
+              <React.Fragment>
+                <div className={styles.schemaObjectContent}>
+                  <span className={styles.enumLabel}>{'one of'}</span>
+                  <button onClick={() => setIsOpenObject(!is_open_object)}>{'stream_types'}</button>
+                  <span className={`${styles.enumType} ${styles.array}`}>{'array'}</span>
+                </div>
+              </React.Fragment>
+            )}
+
             {pattern && (
               <div className={styles.schemaRegexContainer}>
                 <div className={styles.schemaBodyPattern}>{pattern}</div>

--- a/src/features/Apiexplorer/Schema/RecursiveContent/SchemaObjectContent/__tests__/SchemaObjectContent.test.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/SchemaObjectContent/__tests__/SchemaObjectContent.test.tsx
@@ -21,6 +21,37 @@ const fake_properties = {
   },
 };
 
+const stream_types_schema = {
+  properties: {
+    test_property: {
+      description: 'property description',
+      oneOf: 'this is oneOf key',
+    },
+  },
+  definitions: {
+    stream_types: {
+      description: 'This stream_types description',
+      type: 'string',
+      enum: [
+        'balance',
+        'candles',
+        'cashier_payments',
+        'p2p_advert',
+        'p2p_advertiser',
+        'p2p_order',
+        'proposal',
+        'proposal_open_contract',
+        'ticks',
+        'transaction',
+        'trading_platform_asset_listing',
+        'website_status',
+        'p2p_settings',
+        'crypto_estimations',
+      ],
+    },
+  },
+};
+
 describe('SchemaObjectContent', () => {
   it('should be able to open a nested object item', async () => {
     render(<SchemaObjectContent key_value='test_item' properties={fake_properties} />);
@@ -95,5 +126,25 @@ describe('SchemaObjectContent', () => {
 
     const schema = await screen.findByTitle('JSON');
     expect(schema).toBeVisible();
+  });
+
+  it('should open StreamTypesObject upon clicking stream_types button', async () => {
+    render(
+      <SchemaObjectContent
+        key='test_property'
+        key_value='test_property'
+        properties={stream_types_schema.properties}
+        jsonSchema={stream_types_schema}
+        is_stream_types={true}
+      />,
+    );
+
+    const button = await screen.findByRole('button', { name: /stream_types/i });
+    expect(button).toBeVisible();
+
+    await userEvent.click(button);
+
+    const streamTypesObject = await screen.getByTestId('dt_stream_types_object');
+    expect(streamTypesObject).toBeVisible();
   });
 });

--- a/src/features/Apiexplorer/Schema/RecursiveContent/SchemaObjectContent/index.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/SchemaObjectContent/index.tsx
@@ -14,7 +14,6 @@ type TSchemaObjectContent = {
   is_stream_types?: boolean;
 };
 
-//json schema also here full obj
 export default function SchemaObjectContent({
   key_value,
   properties,

--- a/src/features/Apiexplorer/Schema/RecursiveContent/SchemaObjectContent/index.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/SchemaObjectContent/index.tsx
@@ -10,9 +10,17 @@ const ReactJson = React.lazy(() => import('react-json-view'));
 type TSchemaObjectContent = {
   key_value: string;
   properties: any;
+  jsonSchema?: any;
+  is_stream_types?: boolean;
 };
 
-export default function SchemaObjectContent({ key_value, properties }: TSchemaObjectContent) {
+//json schema also here full obj
+export default function SchemaObjectContent({
+  key_value,
+  properties,
+  jsonSchema,
+  is_stream_types = false,
+}: TSchemaObjectContent) {
   const [is_open_object, setIsOpenObject] = useState<boolean>(false);
   const [is_code_open, setIsCodeOpen] = useState<boolean>(false);
   const {
@@ -52,6 +60,7 @@ export default function SchemaObjectContent({ key_value, properties }: TSchemaOb
           title={title}
           is_open_object={is_open_object}
           setIsOpenObject={setIsOpenObject}
+          is_stream_types={is_stream_types}
         />
         {/* Description */}
         <SchemaDescription description={description} />
@@ -68,6 +77,7 @@ export default function SchemaObjectContent({ key_value, properties }: TSchemaOb
             is_open={is_open_object}
             properties={value.properties || value?.items?.properties}
             value={value}
+            jsonSchema={jsonSchema}
           />
         )}
       </div>

--- a/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/StreamTypesBody.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/StreamTypesBody.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import styles from '../../Schema.module.scss';
+
+type TStreamTypesBody = {
+  type: string;
+  _enum: Array<
+    | 'balance'
+    | 'candles'
+    | 'cashier_payments'
+    | 'p2p_advert'
+    | 'p2p_advertiser'
+    | 'p2p_order'
+    | 'proposal'
+    | 'proposal_open_contract'
+    | 'ticks'
+    | 'transaction'
+    | 'trading_platform_asset_listing'
+    | 'website_status'
+    | 'p2p_settings'
+    | 'crypto_estimations'
+  >;
+};
+
+const StreamTypesBody = ({ type, _enum }: TStreamTypesBody) => {
+  return (
+    <div className={styles.streamTypesBody}>
+      <div className={styles.streamTypesObject}>
+        <span className={styles.enumLabel}>enum</span>
+        <span className={`${styles.enumType} ${styles.string}`}>{type}</span>
+        {_enum.map((enum_name: string, i: number) => (
+          <div className={`${styles.schemaCode} ${styles.schemaEnums}`} key={i}>
+            {enum_name}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default StreamTypesBody;

--- a/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/StreamTypesBody.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/StreamTypesBody.tsx
@@ -1,24 +1,10 @@
 import React from 'react';
+import { TEnumStreamType } from '@site/src/types';
 import styles from '../../Schema.module.scss';
 
 type TStreamTypesBody = {
   type: string;
-  _enum: Array<
-    | 'balance'
-    | 'candles'
-    | 'cashier_payments'
-    | 'p2p_advert'
-    | 'p2p_advertiser'
-    | 'p2p_order'
-    | 'proposal'
-    | 'proposal_open_contract'
-    | 'ticks'
-    | 'transaction'
-    | 'trading_platform_asset_listing'
-    | 'website_status'
-    | 'p2p_settings'
-    | 'crypto_estimations'
-  >;
+  _enum: TEnumStreamType;
 };
 
 const StreamTypesBody = ({ type, _enum }: TStreamTypesBody) => {

--- a/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/StreamTypesHeader.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/StreamTypesHeader.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import SchemaTitle from '../../SchemaTitle';
+import styles from '../../Schema.module.scss';
+
+type TStreamTypesHeader = {
+  description: string;
+};
+
+const StreamTypesHeader = ({ description }: TStreamTypesHeader) => {
+  return (
+    <div className={styles.streamTypesHeader}>
+      <SchemaTitle className={styles.streamTypesTitle}>{'stream_types'}</SchemaTitle>
+      <div className={styles.streamTypesDescription}>
+        <div>{description}</div>
+      </div>
+    </div>
+  );
+};
+
+export default StreamTypesHeader;

--- a/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/StreamTypesHeader.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/StreamTypesHeader.tsx
@@ -9,7 +9,7 @@ type TStreamTypesHeader = {
 const StreamTypesHeader = ({ description }: TStreamTypesHeader) => {
   return (
     <div className={styles.streamTypesHeader}>
-      <SchemaTitle className={styles.streamTypesTitle}>{'stream_types'}</SchemaTitle>
+      <SchemaTitle className={styles.streamTypesTitle}>stream_types</SchemaTitle>
       <div className={styles.streamTypesDescription}>
         <div>{description}</div>
       </div>

--- a/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/__tests__/StreamTypesObject.test.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/__tests__/StreamTypesObject.test.tsx
@@ -1,29 +1,28 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { screen, render } from '@testing-library/react';
+import { TEnumStreamType } from '@site/src/types';
 import StreamTypesObject from '..';
 
 describe('StreamTypesObject', () => {
+  const _enum: TEnumStreamType = [
+    'balance',
+    'candles',
+    'cashier_payments',
+    'p2p_advert',
+    'p2p_advertiser',
+    'p2p_order',
+    'proposal',
+    'proposal_open_contract',
+    'ticks',
+    'transaction',
+    'website_status',
+  ];
   const json_schema = {
     stream_types: {
       description: 'This stream_types description',
       type: 'string',
-      enum: [
-        'balance',
-        'candles',
-        'cashier_payments',
-        'p2p_advert',
-        'p2p_advertiser',
-        'p2p_order',
-        'proposal',
-        'proposal_open_contract',
-        'ticks',
-        'transaction',
-        'trading_platform_asset_listing',
-        'website_status',
-        'p2p_settings',
-        'crypto_estimations',
-      ],
+      enum: _enum,
     },
   };
 

--- a/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/__tests__/StreamTypesObject.test.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/__tests__/StreamTypesObject.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+import { screen, render } from '@testing-library/react';
+import StreamTypesObject from '..';
+
+describe('StreamTypesObject', () => {
+  const json_schema = {
+    stream_types: {
+      description: 'This stream_types description',
+      type: 'string',
+      enum: [
+        'balance',
+        'candles',
+        'cashier_payments',
+        'p2p_advert',
+        'p2p_advertiser',
+        'p2p_order',
+        'proposal',
+        'proposal_open_contract',
+        'ticks',
+        'transaction',
+        'trading_platform_asset_listing',
+        'website_status',
+        'p2p_settings',
+        'crypto_estimations',
+      ],
+    },
+  };
+
+  it('should render button that opens jsonschema', async () => {
+    render(<StreamTypesObject definitions={json_schema} />);
+
+    const schema_button = await screen.findByText('{}');
+
+    expect(schema_button).toBeVisible();
+
+    await userEvent.click(schema_button);
+
+    const schema = await screen.findByTitle('JSON');
+    expect(schema).toBeVisible();
+  });
+
+  it('should render the header of the object', () => {
+    render(<StreamTypesObject definitions={json_schema} />);
+
+    const header_title = screen.getAllByText(/stream_types/)[0];
+    expect(header_title).toBeInTheDocument();
+
+    const header_description = screen.getByText(/This stream_types description/i);
+    expect(header_description).toBeInTheDocument();
+  });
+
+  it('should render the body of StreamTypesObject', () => {
+    render(<StreamTypesObject definitions={json_schema} />);
+
+    const type = screen.getByText(/enum/i);
+    expect(type).toBeInTheDocument();
+
+    const enum_type = screen.getByText(/string/i);
+    expect(enum_type).toBeInTheDocument();
+
+    json_schema.stream_types.enum.map((item) => {
+      const enum_name = screen.getByText(item);
+      expect(enum_name).toBeInTheDocument();
+    });
+  });
+});

--- a/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/index.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/index.tsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react';
 import StreamTypesHeader from './StreamTypesHeader';
 import StreamTypesBody from './StreamTypesBody';
 import SourceButton from '../../SourceButton/SourceButton';
+import { TEnumStreamType } from '@site/src/types';
 import styles from '../../Schema.module.scss';
 
 type TStreamTypesObject = {
@@ -9,7 +10,7 @@ type TStreamTypesObject = {
     stream_types: {
       description: string;
       type: string;
-      enum;
+      enum: TEnumStreamType;
     };
   };
 };

--- a/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/index.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/index.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import StreamTypesHeader from './StreamTypesHeader';
+import StreamTypesBody from './StreamTypesBody';
+import styles from '../../Schema.module.scss';
+
+type TStreamTypesObject = {
+  definitions: {
+    stream_types: {
+      description: string;
+      type: string;
+      enum: Array<
+        | 'balance'
+        | 'candles'
+        | 'cashier_payments'
+        | 'p2p_advert'
+        | 'p2p_advertiser'
+        | 'p2p_order'
+        | 'proposal'
+        | 'proposal_open_contract'
+        | 'ticks'
+        | 'transaction'
+        | 'trading_platform_asset_listing'
+        | 'website_status'
+        | 'p2p_settings'
+        | 'crypto_estimations'
+      >;
+    };
+  };
+};
+
+const StreamTypesObject = ({ definitions }: TStreamTypesObject) => {
+  return (
+    <div className={styles.streamTypesContainer}>
+      <StreamTypesHeader description={definitions.stream_types.description} />
+      <StreamTypesBody type={definitions.stream_types.type} _enum={definitions.stream_types.enum} />
+    </div>
+  );
+};
+
+export default StreamTypesObject;

--- a/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/index.tsx
+++ b/src/features/Apiexplorer/Schema/RecursiveContent/StreamTypesObject/index.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import StreamTypesHeader from './StreamTypesHeader';
 import StreamTypesBody from './StreamTypesBody';
+import SourceButton from '../../SourceButton/SourceButton';
 import styles from '../../Schema.module.scss';
 
 type TStreamTypesObject = {
@@ -8,31 +9,38 @@ type TStreamTypesObject = {
     stream_types: {
       description: string;
       type: string;
-      enum: Array<
-        | 'balance'
-        | 'candles'
-        | 'cashier_payments'
-        | 'p2p_advert'
-        | 'p2p_advertiser'
-        | 'p2p_order'
-        | 'proposal'
-        | 'proposal_open_contract'
-        | 'ticks'
-        | 'transaction'
-        | 'trading_platform_asset_listing'
-        | 'website_status'
-        | 'p2p_settings'
-        | 'crypto_estimations'
-      >;
+      enum;
     };
   };
 };
 
+const ReactJson = React.lazy(() => import('react-json-view'));
+
 const StreamTypesObject = ({ definitions }: TStreamTypesObject) => {
+  const [is_code_open, setIsCodeOpen] = React.useState(false);
+  let data = '';
+  try {
+    data = JSON.stringify(definitions.stream_types, null, 2);
+  } catch (error) {
+    data = '';
+    console.error('There was an issue stringifying JSON data: ', error);
+  }
   return (
-    <div className={styles.streamTypesContainer}>
+    <div className={styles.streamTypesContainer} data-testid='dt_stream_types_object'>
+      <SourceButton is_code_open={is_code_open} setIsCodeOpen={setIsCodeOpen} />
       <StreamTypesHeader description={definitions.stream_types.description} />
-      <StreamTypesBody type={definitions.stream_types.type} _enum={definitions.stream_types.enum} />
+      {is_code_open ? (
+        <React.Fragment>
+          <Suspense fallback={<div style={{ color: 'white' }}>Loading...</div>}>
+            <ReactJson src={JSON.parse(data)} theme='tube' />
+          </Suspense>
+        </React.Fragment>
+      ) : (
+        <StreamTypesBody
+          type={definitions.stream_types.type}
+          _enum={definitions.stream_types.enum}
+        />
+      )}
     </div>
   );
 };

--- a/src/features/Apiexplorer/Schema/Schema.module.scss
+++ b/src/features/Apiexplorer/Schema/Schema.module.scss
@@ -304,14 +304,44 @@
 }
 
 .streamTypesContainer {
-  border-radius: 6px;
   margin-top: rem(1);
   margin-bottom: rem(2.4);
+
+  &:hover {
+    > .sourceButtonMain {
+      opacity: 1;
+      margin: 10px;
+    }
+  }
+
+  .streamTypesHeader {
+    padding: rem(1);
+    border: none;
+    background: #151717;
+    border-top-left-radius: 6px;
+    border-top-right-radius: 6px;
+
+    .streamTypesTitle {
+      font-size: rem(1.6);
+      color: var(--ifm-color-white);
+      font-weight: bold;
+    }
+    .streamTypesDescription {
+      display: flex;
+      padding: rem(0.5) 0;
+      gap: rem(2);
+      justify-content: space-between;
+      color: var(--ifm-color-white);
+      font-size: rem(1.4);
+    }
+  }
 
   .streamTypesBody {
     background-color: rgba(219, 219, 219, 0.05);
     display: flex;
     padding: rem(1);
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
 
     .streamTypesObject {
       display: flex;
@@ -350,26 +380,6 @@
         border-radius: 4px;
         background-color: rgba(0, 255, 104, 0.16);
       }
-    }
-  }
-
-  .streamTypesHeader {
-    padding: rem(1);
-    border: none;
-    background: #151717;
-
-    .streamTypesTitle {
-      font-size: rem(1.6);
-      color: var(--ifm-color-white);
-      font-weight: bold;
-    }
-    .streamTypesDescription {
-      display: flex;
-      padding: rem(0.5) 0;
-      gap: rem(2);
-      justify-content: space-between;
-      color: var(--ifm-color-white);
-      font-size: rem(1.4);
     }
   }
 }

--- a/src/features/Apiexplorer/Schema/Schema.module.scss
+++ b/src/features/Apiexplorer/Schema/Schema.module.scss
@@ -92,6 +92,7 @@
   cursor: pointer;
   font-weight: 500;
   transition: opacity 0.2s ease-in-out;
+  z-index: 1;
 }
 
 .schemaBody {

--- a/src/features/Apiexplorer/Schema/Schema.module.scss
+++ b/src/features/Apiexplorer/Schema/Schema.module.scss
@@ -34,6 +34,7 @@
   display: flex;
   flex-direction: row;
   position: relative;
+  gap: rem(0.8);
 
   p {
     color: var(--ifm-color-white);
@@ -300,4 +301,75 @@
 
 .reactJsonView {
   margin-bottom: rem(2.4);
+}
+
+.streamTypesContainer {
+  border-radius: 6px;
+  margin-top: rem(1);
+  margin-bottom: rem(2.4);
+
+  .streamTypesBody {
+    background-color: rgba(219, 219, 219, 0.05);
+    display: flex;
+    padding: rem(1);
+
+    .streamTypesObject {
+      display: flex;
+      flex-wrap: wrap;
+      gap: rem(0.8);
+      align-items: center;
+
+      .enumLabel {
+        font-size: rem(1.4);
+        line-height: rem(1.4);
+        color: var(--ifm-color-emphasis-200);
+      }
+
+      .enumType {
+        font-size: rem(1.4);
+        &.string {
+          color: var(--schema-string);
+        }
+      }
+
+      .enumLabel,
+      .enumType {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .schemaEnums {
+        width: fit-content;
+        height: fit-content;
+        font-size: rem(1.4);
+        line-height: rem(1.4);
+        color: var(--ifm-color-success-light);
+        border: none;
+        padding: rem(0.6) rem(0.8);
+        border-radius: 4px;
+        background-color: rgba(0, 255, 104, 0.16);
+      }
+    }
+  }
+
+  .streamTypesHeader {
+    padding: rem(1);
+    border: none;
+    background: #151717;
+
+    .streamTypesTitle {
+      font-size: rem(1.6);
+      color: var(--ifm-color-white);
+      font-weight: bold;
+    }
+    .streamTypesDescription {
+      display: flex;
+      padding: rem(0.5) 0;
+      gap: rem(2);
+      justify-content: space-between;
+      color: var(--ifm-color-white);
+      font-size: rem(1.4);
+    }
+  }
 }

--- a/src/features/Apiexplorer/Schema/Schema.module.scss
+++ b/src/features/Apiexplorer/Schema/Schema.module.scss
@@ -310,7 +310,7 @@
   &:hover {
     > .sourceButtonMain {
       opacity: 1;
-      margin: 10px;
+      margin: rem(1);
     }
   }
 

--- a/src/features/Apiexplorer/Schema/SchemaProperties/index.tsx
+++ b/src/features/Apiexplorer/Schema/SchemaProperties/index.tsx
@@ -32,6 +32,7 @@ const SchemaProperties = ({ jsonSchema }: TJsonSchemaType) => {
           is_open
           properties={jsonSchema.properties}
           value={jsonSchema.properties}
+          jsonSchema={jsonSchema}
         />
       )}
     </React.Fragment>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-import { ApiToken } from '@deriv/api-types';
+import { ApiToken, StreamTypes } from '@deriv/api-types';
 import { Column } from 'react-table';
 
 export type TTokensArrayType = ApiToken['tokens'];
@@ -15,3 +15,5 @@ export type TInfo = {
   auth_required?: number;
   auth_scopes?: string[];
 };
+
+export type TEnumStreamType = Array<StreamTypes>;


### PR DESCRIPTION
This PR adds stream_types to api.deriv.com. Stream_types was initially available on developers.binary.com for forgetAll api call. On clicking the stream_types tag we get a box describing stream_types as well as a JSON object upon clicking the source button inside stream_types object. The PR covers implementation of these features as well as test cases.

Api.deriv.com
<img width="581" alt="Screenshot 2023-12-05 at 11 52 34 AM" src="https://github.com/binary-com/deriv-api-docs/assets/125863995/0c9498f1-db29-48e3-9950-9fb08d5bbabb">

Developers.binary.com
![image](https://github.com/binary-com/deriv-api-docs/assets/125863995/727cb5b0-9d47-4e76-8c65-7530c8646579)
