### PR TITLE
[API] Fix: error message JSON body was not displaying correctly

### DIFF
--- a/src/features/Apiexplorer/SubscribeRenderer/index.tsx
+++ b/src/features/Apiexplorer/SubscribeRenderer/index.tsx
@@ -32,7 +32,12 @@ function SubscribeRenderer<T extends TSocketSubscribableEndpointNames>({
   const [is_not_valid, setIsNotValid] = useState(false);
 
   useEffect(() => {
-    if (error && error.code === 'AuthorizationRequired') {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'AuthorizationRequired'
+    ) {
       setToggleModal(true);
     }
   }, [error]);

--- a/src/hooks/useSubscription/index.tsx
+++ b/src/hooks/useSubscription/index.tsx
@@ -6,15 +6,10 @@ import {
 } from '@site/src/configs/websocket/types';
 import { useCallback, useState } from 'react';
 
-type TError = {
-  code?: string;
-  message?: string;
-};
-
 const useSubscription = <T extends TSocketSubscribableEndpointNames>(name: T) => {
   const [is_loading, setIsLoading] = useState(false);
   const [is_subscribed, setSubscribed] = useState(false);
-  const [error, setError] = useState<TError>();
+  const [error, setError] = useState<unknown>();
   const [data, setData] = useState<TSocketResponseData<T>>();
   const [full_response, setFullResponse] = useState<TSocketResponse<T>>();
   const [subscriber, setSubscriber] = useState<{ unsubscribe?: VoidFunction }>();
@@ -30,7 +25,7 @@ const useSubscription = <T extends TSocketSubscribableEndpointNames>(name: T) =>
   );
 
   const onError = useCallback((response: TSocketResponse<T>) => {
-    setError(response.error);
+    setError(response);
     setIsLoading(false);
     setFullResponse(null);
   }, []);


### PR DESCRIPTION
This PR fixes the bug 🐛  of displaying error in the `JSON response body` so If user have selected any API call from the dropdown list and send a custom JSON request with `"subscribe": 1` as part of the key, we will get Input validation failed: error in the response body. 