### PR TITLE
chore: :zap: updated trackjs app name

### DIFF
--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -15,7 +15,7 @@ type TRootProps = {
 
 if (siteConfig.customFields.trackJsToken) {
   TrackJS.install({
-    application: 'api.deriv.com',
+    application: 'api-deriv-com',
     token: siteConfig.customFields.trackJsToken.toString(),
   });
 } else {


### PR DESCRIPTION
## change

- Update trackjs app name from `api.deriv.com` to `app-deriv-com` as per the trackjs config
<img width="235" alt="Screenshot 2024-03-21 at 4 54 08 PM" src="https://github.com/binary-com/deriv-api-docs/assets/90243468/daf96d7d-f209-4bb7-9154-1b7459fad53d">
