### PR TITLE
fix: :fire: added tUSDT icon and currency name in tthe account switcher

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,6 +14,7 @@ const CURRENCY_MAP = new Map([
   ['Demo', { icon: 'demo', name: 'Demo' }],
   ['UST', { icon: 'tether', name: 'Tether Omni' }],
   ['eUSDT', { icon: 'tether', name: 'Tether ERC20' }],
+  ['tUSDT', { icon: 'tether', name: 'Tether TRC20' }],
   ['BTC', { icon: 'bitcoin', name: 'Bitcoin' }],
   ['ETH', { icon: 'ethereum', name: 'Ethereum' }],
   ['LTC', { icon: 'litecoin', name: 'Litecoin' }],


### PR DESCRIPTION
## Change
- Added missing iUSDT icon and currency name in the account switcher

## Screenshot

### Desktop

<img width="391" alt="Screenshot 2024-04-04 at 11 12 56 AM" src="https://github.com/binary-com/deriv-api-docs/assets/90243468/bded150b-6ad4-4e3f-b7b9-8355032f12fc">

### Mobile

<img width="378" alt="Screenshot 2024-04-04 at 11 13 22 AM" src="https://github.com/binary-com/deriv-api-docs/assets/90243468/4d2d51ba-7b9f-4ca6-a61c-6cd01867182c">
