### PR TITLE
Agrim/DAPI-458/fix  js api docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
-  "editor.codeActionsOnSave": { "source.fixAll.eslint": true },
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
-  },
+  "editor.codeActionsOnSave": { "source.fixAll.eslint": true },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true
 }

--- a/src/features/Home/ClientLibraries/ClientLibraries.tsx
+++ b/src/features/Home/ClientLibraries/ClientLibraries.tsx
@@ -27,7 +27,7 @@ export const ClientLibraries = () => {
           <div className={styles.LogoAndLink}>
             <a
               className={styles.LibraryGoTo}
-              href='https://binary-com.github.io/deriv-api/'
+              href='https://deriv-com.github.io/deriv-api/'
               rel='noreferrer'
               target='_blank'
             >

--- a/src/features/Home/ClientLibraries/__tests__/ClientLibraries.test.tsx
+++ b/src/features/Home/ClientLibraries/__tests__/ClientLibraries.test.tsx
@@ -26,7 +26,7 @@ describe('ClientLibraries', () => {
   it('should navigate to the correct links on click', () => {
     expect(screen.getByText('Go to the JavaScript library').closest('a')).toHaveAttribute(
       'href',
-      'https://binary-com.github.io/deriv-api/',
+      'https://deriv-com.github.io/deriv-api/',
     );
     expect(screen.getByText('Go to the Python library').closest('a')).toHaveAttribute(
       'href',


### PR DESCRIPTION
Changing the URL for the javascript api docs from binary to deriv since the link in current production wasn't working with binary-com. 